### PR TITLE
Create new event grid topic and subscription

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,10 +33,12 @@
         "onCommand:azureEventGridTopic.refresh",
         "onCommand:azureEventGridTopic.loadMore",
         "onCommand:azureEventGridTopic.openInPortal",
+        "onCommand:azureEventGridTopic.createTopic",
         "onCommand:azureEventGridTopic.deleteTopic",
         "onCommand:azureEventGridSubscription.refresh",
         "onCommand:azureEventGridSubscription.loadMore",
         "onCommand:azureEventGridSubscription.openInPortal",
+        "onCommand:azureEventGridSubscription.createEventSubscription",
         "onCommand:azureEventGridSubscription.deleteEventSubscription",
         "onView:azureEventGridTopicExplorer",
         "onView:azureEventGridSubscriptionExplorer"
@@ -73,6 +75,11 @@
                 "category": "Azure Event Grid Topic"
             },
             {
+                "command": "azureEventGridTopic.createTopic",
+                "title": "%createTopic%",
+                "category": "Azure Event Grid Topic"
+            },
+            {
                 "command": "azureEventGridTopic.deleteTopic",
                 "title": "%delete%",
                 "category": "Azure Event Grid Topic"
@@ -94,6 +101,11 @@
             {
                 "command": "azureEventGridSubscription.openInPortal",
                 "title": "%openInPortal%",
+                "category": "Azure Event Grid Subscription"
+            },
+            {
+                "command": "azureEventGridSubscription.createEventSubscription",
+                "title": "%createEventSubscription%",
                 "category": "Azure Event Grid Subscription"
             },
             {
@@ -134,14 +146,19 @@
                     "group": "inline"
                 },
                 {
-                    "command": "azureEventGridTopic.openInPortal",
+                    "command": "azureEventGridTopic.createTopic",
                     "when": "view == azureEventGridTopicExplorer && viewItem == azureextensionui.azureSubscription",
                     "group": "1@1"
                 },
                 {
-                    "command": "azureEventGridTopic.refresh",
+                    "command": "azureEventGridTopic.openInPortal",
                     "when": "view == azureEventGridTopicExplorer && viewItem == azureextensionui.azureSubscription",
                     "group": "2@1"
+                },
+                {
+                    "command": "azureEventGridTopic.refresh",
+                    "when": "view == azureEventGridTopicExplorer && viewItem == azureextensionui.azureSubscription",
+                    "group": "3@1"
                 },
                 {
                     "command": "azureEventGridTopic.openInPortal",
@@ -159,14 +176,19 @@
                     "group": "inline"
                 },
                 {
-                    "command": "azureEventGridSubscription.openInPortal",
+                    "command": "azureEventGridSubscription.createEventSubscription",
                     "when": "view == azureEventGridSubscriptionExplorer && viewItem == azureextensionui.azureSubscription",
                     "group": "1@1"
                 },
                 {
-                    "command": "azureEventGridSubscription.refresh",
+                    "command": "azureEventGridSubscription.openInPortal",
                     "when": "view == azureEventGridSubscriptionExplorer && viewItem == azureextensionui.azureSubscription",
                     "group": "2@1"
+                },
+                {
+                    "command": "azureEventGridSubscription.refresh",
+                    "when": "view == azureEventGridSubscriptionExplorer && viewItem == azureextensionui.azureSubscription",
+                    "group": "3@1"
                 },
                 {
                     "command": "azureEventGridSubscription.openInPortal",
@@ -230,7 +252,7 @@
     "dependencies": {
         "azure-arm-eventgrid": "^1.1.0-preview",
         "azure-arm-resource": "^3.1.1-preview",
-        "vscode-azureextensionui": "~0.11.1",
+        "vscode-azureextensionui": "~0.12.0",
         "vscode-extension-telemetry": "^0.0.15",
         "vscode-nls": "^2.0.2"
     },

--- a/package.nls.json
+++ b/package.nls.json
@@ -4,5 +4,7 @@
     "selectSubscriptions": "Select Subscriptions...",
     "loadMore": "Load More...",
     "openInPortal": "Open In Portal",
+    "createEventSubscription": "Create Event Subscription",
+    "createTopic": "Create Topic",
     "delete": "Delete"
 }

--- a/src/commands/createChildNode.ts
+++ b/src/commands/createChildNode.ts
@@ -1,0 +1,14 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { AzureTreeDataProvider, IActionContext, IAzureParentNode } from 'vscode-azureextensionui';
+
+export async function createChildNode(actionContext: IActionContext, tree: AzureTreeDataProvider, expectedContextValue: string, node?: IAzureParentNode): Promise<void> {
+    if (!node) {
+        node = <IAzureParentNode>await tree.showNodePicker(expectedContextValue);
+    }
+
+    await node.createChild(actionContext);
+}

--- a/src/eventSubscription/createWizard/EndpointUrlStep.ts
+++ b/src/eventSubscription/createWizard/EndpointUrlStep.ts
@@ -1,0 +1,21 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { AzureWizardPromptStep, IAzureUserInput } from 'vscode-azureextensionui';
+import { localize } from '../../utils/localize';
+import { IEventSubscriptionWizardContext } from "./IEventSubscriptionWizardContext";
+
+export class EndpointUrlStep extends AzureWizardPromptStep<IEventSubscriptionWizardContext> {
+    public async prompt(wizardContext: IEventSubscriptionWizardContext, ui: IAzureUserInput): Promise<IEventSubscriptionWizardContext> {
+        if (!wizardContext.endpointUrl) {
+            wizardContext.endpointUrl = (await ui.showInputBox({
+                placeHolder: localize('urlPlaceholder', 'Subscriber Endpoint'),
+                prompt: localize('urlPrompt', 'Provide a subscriber endpoint.')
+            })).trim();
+        }
+
+        return wizardContext;
+    }
+}

--- a/src/eventSubscription/createWizard/EventSubscriptionCreateStep.ts
+++ b/src/eventSubscription/createWizard/EventSubscriptionCreateStep.ts
@@ -1,0 +1,56 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// tslint:disable-next-line:no-require-imports
+import EventGridManagementClient = require('azure-arm-eventgrid');
+import { WebHookEventSubscriptionDestination } from 'azure-arm-eventgrid/lib/models';
+import { OutputChannel } from 'vscode';
+import { AzureWizardExecuteStep, IResourceGroupWizardContext, IStorageAccountWizardContext } from 'vscode-azureextensionui';
+import { ITopicWizardContext } from '../../topic/createWizard/ITopicWizardContext';
+import { localize } from '../../utils/localize';
+import { IEventSubscriptionWizardContext } from "./IEventSubscriptionWizardContext";
+import { TopicType } from './TopicTypeStep';
+
+export class EventSubscriptionCreateStep extends AzureWizardExecuteStep<IEventSubscriptionWizardContext> {
+    public async execute(wizardContext: IEventSubscriptionWizardContext, outputChannel: OutputChannel): Promise<IEventSubscriptionWizardContext> {
+        if (!wizardContext.eventSubscription) {
+            let topicId: string;
+            switch (wizardContext.topicType) {
+                case TopicType.StorageAccount:
+                    // tslint:disable-next-line:no-non-null-assertion
+                    topicId = (<IStorageAccountWizardContext>wizardContext).storageAccount!.id!;
+                    break;
+                case TopicType.Subscription:
+                    topicId = `/subscriptions/${wizardContext.subscriptionId}`;
+                    break;
+                case TopicType.ResourceGroup:
+                    // tslint:disable-next-line:no-non-null-assertion
+                    topicId = (<IResourceGroupWizardContext>wizardContext).resourceGroup!.id!;
+                    break;
+                case TopicType.EventGridTopic:
+                    // tslint:disable-next-line:no-non-null-assertion
+                    topicId = (<ITopicWizardContext>wizardContext).topic!.id!;
+                    break;
+                default:
+                    throw new Error(localize('unrecognizedTopicType', 'Unrecognized topic type "{0}".', wizardContext.topicType));
+            }
+
+            outputChannel.appendLine(localize('creating', 'Creating event subscription "{0}" for topic "{1}"...', wizardContext.newEventSubscriptionName, topicId));
+
+            const client: EventGridManagementClient = new EventGridManagementClient(wizardContext.credentials, wizardContext.subscriptionId);
+            // tslint:disable-next-line:no-non-null-assertion
+            wizardContext.eventSubscription = await client.eventSubscriptions.createOrUpdate(topicId, wizardContext.newEventSubscriptionName!, {
+                destination: <WebHookEventSubscriptionDestination>{
+                    endpointUrl: wizardContext.endpointUrl,
+                    endpointType: 'WebHook'
+                }
+            });
+
+            outputChannel.appendLine(localize('created', 'Successfully created event subscription "{0}".', wizardContext.newEventSubscriptionName));
+        }
+
+        return wizardContext;
+    }
+}

--- a/src/eventSubscription/createWizard/EventSubscriptionNameStep.ts
+++ b/src/eventSubscription/createWizard/EventSubscriptionNameStep.ts
@@ -1,0 +1,46 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { AzureNameStep, IAzureUserInput, ResourceGroupListStep, resourceGroupNamingRules } from 'vscode-azureextensionui';
+import { localize } from '../../utils/localize';
+import { IEventSubscriptionWizardContext } from "./IEventSubscriptionWizardContext";
+
+export class EventSubscriptionNameStep extends AzureNameStep<IEventSubscriptionWizardContext> {
+    public async prompt(wizardContext: IEventSubscriptionWizardContext, ui: IAzureUserInput): Promise<IEventSubscriptionWizardContext> {
+        if (!wizardContext.newEventSubscriptionName) {
+            const suggestedName: string | undefined = wizardContext.relatedNameTask ? await wizardContext.relatedNameTask : undefined;
+            wizardContext.newEventSubscriptionName = (await ui.showInputBox({
+                value: suggestedName,
+                placeHolder: localize('namePlaceholder', 'Event subscription name'),
+                prompt: localize('namePrompt', 'Provide an event subscription name.'),
+                validateInput: this.validateName
+            })).trim();
+
+            if (!wizardContext.relatedNameTask) {
+                wizardContext.relatedNameTask = this.generateRelatedName(wizardContext, wizardContext.newEventSubscriptionName, resourceGroupNamingRules);
+            }
+        }
+
+        return wizardContext;
+    }
+
+    protected async isRelatedNameAvailable(wizardContext: IEventSubscriptionWizardContext, name: string): Promise<boolean> {
+        return ResourceGroupListStep.isNameAvailable(wizardContext, name);
+    }
+
+    private async validateName(name: string | undefined): Promise<string | undefined> {
+        name = name ? name.trim() : '';
+
+        const min: number = 3;
+        const max: number = 64;
+        if (name.length < min || name.length > max) {
+            return localize('invalidLength', 'The name must be between {0} and {1} characters.', min, max);
+        } else if (name.match(/[^a-zA-Z0-9\-]/) !== null) {
+            return localize('invalidChars', "The name can only contain letters, numbers, and hyphens.");
+        } else {
+            return undefined;
+        }
+    }
+}

--- a/src/eventSubscription/createWizard/IEventSubscriptionWizardContext.ts
+++ b/src/eventSubscription/createWizard/IEventSubscriptionWizardContext.ts
@@ -1,0 +1,16 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { EventSubscription } from "azure-arm-eventgrid/lib/models";
+import { IRelatedNameWizardContext, ISubscriptionWizardContext } from "vscode-azureextensionui";
+import { TopicType } from "./TopicTypeStep";
+
+export interface IEventSubscriptionWizardContext extends ISubscriptionWizardContext, IRelatedNameWizardContext {
+    eventSubscription?: EventSubscription;
+
+    newEventSubscriptionName?: string;
+    topicType?: TopicType;
+    endpointUrl?: string;
+}

--- a/src/eventSubscription/createWizard/TopicListStep.ts
+++ b/src/eventSubscription/createWizard/TopicListStep.ts
@@ -17,7 +17,7 @@ export class TopicListStep<T extends ITopicWizardContext> extends AzureWizardPro
         if (!wizardContext.topic) {
             const client: EventGridManagementClient = new EventGridManagementClient(wizardContext.credentials, wizardContext.subscriptionId);
 
-            const quickPickOptions: IAzureQuickPickOptions = { placeHolder: 'Select a topic.', id: `TopicListStep/${wizardContext.subscriptionId}` };
+            const quickPickOptions: IAzureQuickPickOptions = { placeHolder: localize('topicPlaceHolder', 'Select a topic'), id: `TopicListStep/${wizardContext.subscriptionId}` };
             wizardContext.topic = (await ui.showQuickPick(this.getQuickPicks(client.topics.listBySubscription()), quickPickOptions)).data;
 
             if (!wizardContext.topic) {

--- a/src/eventSubscription/createWizard/TopicListStep.ts
+++ b/src/eventSubscription/createWizard/TopicListStep.ts
@@ -1,0 +1,59 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// tslint:disable-next-line:no-require-imports
+import EventGridManagementClient = require('azure-arm-eventgrid');
+import { Topic } from 'azure-arm-eventgrid/lib/models';
+import { AzureWizard, AzureWizardPromptStep, IAzureQuickPickItem, IAzureQuickPickOptions, IAzureUserInput, LocationListStep, ResourceGroupListStep } from 'vscode-azureextensionui';
+import { ITopicWizardContext } from '../../topic/createWizard/ITopicWizardContext';
+import { TopicCreateStep } from '../../topic/createWizard/TopicCreateStep';
+import { TopicNameStep } from '../../topic/createWizard/TopicNameStep';
+import { localize } from '../../utils/localize';
+
+export class TopicListStep<T extends ITopicWizardContext> extends AzureWizardPromptStep<T> {
+    public async prompt(wizardContext: T, ui: IAzureUserInput): Promise<T> {
+        if (!wizardContext.topic) {
+            const client: EventGridManagementClient = new EventGridManagementClient(wizardContext.credentials, wizardContext.subscriptionId);
+
+            const quickPickOptions: IAzureQuickPickOptions = { placeHolder: 'Select a topic.', id: `TopicListStep/${wizardContext.subscriptionId}` };
+            wizardContext.topic = (await ui.showQuickPick(this.getQuickPicks(client.topics.listBySubscription()), quickPickOptions)).data;
+
+            if (!wizardContext.topic) {
+                this.subWizard = new AzureWizard(
+                    [
+                        new TopicNameStep(),
+                        new ResourceGroupListStep(),
+                        new LocationListStep()
+                    ],
+                    [
+                        new TopicCreateStep()
+                    ],
+                    wizardContext
+                );
+            }
+        }
+
+        return wizardContext;
+    }
+
+    private async getQuickPicks(topicsTask: Promise<Topic[]>): Promise<IAzureQuickPickItem<Topic | undefined>[]> {
+        const picks: IAzureQuickPickItem<Topic | undefined>[] = [{
+            label: localize('newTopic', '$(plus) Create new topic'),
+            description: '',
+            data: undefined
+        }];
+
+        const topics: Topic[] = await topicsTask;
+        return picks.concat(topics.map((t: Topic) => {
+            return {
+                id: t.id,
+                // tslint:disable-next-line:no-non-null-assertion
+                label: t.name!,
+                description: '',
+                data: t
+            };
+        }));
+    }
+}

--- a/src/eventSubscription/createWizard/TopicTypeStep.ts
+++ b/src/eventSubscription/createWizard/TopicTypeStep.ts
@@ -1,0 +1,69 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { AzureWizard, AzureWizardPromptStep, IAzureQuickPickItem, IAzureUserInput, ResourceGroupListStep, StorageAccountKind, StorageAccountListStep, StorageAccountPerformance, StorageAccountReplication } from 'vscode-azureextensionui';
+import { localize } from '../../utils/localize';
+import { IEventSubscriptionWizardContext } from "./IEventSubscriptionWizardContext";
+import { TopicListStep } from './TopicListStep';
+
+export enum TopicType {
+    StorageAccount = 'Storage Accounts',
+    Subscription = 'Azure Subscriptions',
+    ResourceGroup = 'Resource Groups',
+    EventGridTopic = 'Event Grid Topics'
+}
+
+export class TopicTypeStep extends AzureWizardPromptStep<IEventSubscriptionWizardContext> {
+    public async prompt(wizardContext: IEventSubscriptionWizardContext, ui: IAzureUserInput): Promise<IEventSubscriptionWizardContext> {
+        if (wizardContext.topicType === undefined) {
+            const picks: IAzureQuickPickItem<TopicType>[] = Object.keys(TopicType).map((key: string) => {
+                return {
+                    label: TopicType[key],
+                    description: '',
+                    data: TopicType[key]
+                };
+            });
+
+            wizardContext.topicType = (await ui.showQuickPick(picks, { placeHolder: localize('selectType', 'Select a topic type') })).data;
+
+            switch (wizardContext.topicType) {
+                case TopicType.StorageAccount:
+                    this.subWizard = new AzureWizard(
+                        [
+                            new StorageAccountListStep(StorageAccountKind.StorageV2, StorageAccountPerformance.Standard, StorageAccountReplication.LRS)
+                        ],
+                        [],
+                        wizardContext
+                    );
+                    break;
+                case TopicType.Subscription:
+                    // no subWizard necessary
+                    break;
+                case TopicType.ResourceGroup:
+                    this.subWizard = new AzureWizard(
+                        [
+                            new ResourceGroupListStep()
+                        ],
+                        [],
+                        wizardContext
+                    );
+                    break;
+                case TopicType.EventGridTopic:
+                    this.subWizard = new AzureWizard(
+                        [
+                            new TopicListStep()
+                        ],
+                        [],
+                        wizardContext
+                    );
+                    break;
+                default:
+                    throw new Error(localize('unrecognizedTopicType', 'Unrecognized topic type "{0}".', wizardContext.topicType));
+            }
+        }
+
+        return wizardContext;
+    }
+}

--- a/src/eventSubscription/registerEventSubscriptionCommands.ts
+++ b/src/eventSubscription/registerEventSubscriptionCommands.ts
@@ -4,20 +4,22 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import { AzureActionHandler, AzureTreeDataProvider, IAzureNode, IAzureUserInput } from 'vscode-azureextensionui';
-import TelemetryReporter from 'vscode-extension-telemetry';
+import { AzureTreeDataProvider, IActionContext, IAzureNode, IAzureParentNode } from 'vscode-azureextensionui';
+import { createChildNode } from '../commands/createChildNode';
 import { deleteNode } from '../commands/deleteNode';
 import { openInPortal } from '../commands/openInPortal';
+import { ext } from '../extensionVariables';
 import { EventSubscriptionProvider } from './tree/EventSubscriptionProvider';
 import { EventSubscriptionTreeItem } from './tree/EventSubscriptionTreeItem';
 
-export function registerEventSubscriptionCommands(context: vscode.ExtensionContext, actionHandler: AzureActionHandler, ui: IAzureUserInput, reporter: TelemetryReporter | undefined): void {
-    const tree: AzureTreeDataProvider = new AzureTreeDataProvider(new EventSubscriptionProvider(), 'azureEventGridSubscription.loadMore', ui, reporter);
-    context.subscriptions.push(tree);
-    context.subscriptions.push(vscode.window.registerTreeDataProvider('azureEventGridSubscriptionExplorer', tree));
+export function registerEventSubscriptionCommands(): void {
+    ext.eventSubscriptionTree = new AzureTreeDataProvider(new EventSubscriptionProvider(), 'azureEventGridSubscription.loadMore', ext.ui, ext.reporter);
+    ext.context.subscriptions.push(ext.eventSubscriptionTree);
+    ext.context.subscriptions.push(vscode.window.registerTreeDataProvider('azureEventGridSubscriptionExplorer', ext.eventSubscriptionTree));
 
-    actionHandler.registerCommand('azureEventGridSubscription.refresh', async (node?: IAzureNode) => await tree.refresh(node));
-    actionHandler.registerCommand('azureEventGridSubscription.loadMore', async (node: IAzureNode) => await tree.loadMore(node));
-    actionHandler.registerCommand('azureEventGridSubscription.openInPortal', async (node?: IAzureNode) => await openInPortal(tree, EventSubscriptionTreeItem.contextValue, node));
-    actionHandler.registerCommand('azureEventGridSubscription.deleteEventSubscription', async (node?: IAzureNode) => await deleteNode(tree, EventSubscriptionTreeItem.contextValue, node));
+    ext.actionHandler.registerCommand('azureEventGridSubscription.refresh', async (node?: IAzureNode) => await ext.eventSubscriptionTree.refresh(node));
+    ext.actionHandler.registerCommand('azureEventGridSubscription.loadMore', async (node: IAzureNode) => await ext.eventSubscriptionTree.loadMore(node));
+    ext.actionHandler.registerCommand('azureEventGridSubscription.openInPortal', async (node?: IAzureNode) => await openInPortal(ext.eventSubscriptionTree, EventSubscriptionTreeItem.contextValue, node));
+    ext.actionHandler.registerCommand('azureEventGridSubscription.deleteEventSubscription', async (node?: IAzureNode) => await deleteNode(ext.eventSubscriptionTree, EventSubscriptionTreeItem.contextValue, node));
+    ext.actionHandler.registerCommand('azureEventGridSubscription.createEventSubscription', async function (this: IActionContext, node?: IAzureParentNode): Promise<void> { await createChildNode(this, ext.eventSubscriptionTree, AzureTreeDataProvider.subscriptionContextValue, node); });
 }

--- a/src/eventSubscription/tree/EventSubscriptionTreeItem.ts
+++ b/src/eventSubscription/tree/EventSubscriptionTreeItem.ts
@@ -7,7 +7,7 @@
 import EventGridManagementClient = require('azure-arm-eventgrid');
 import { EventSubscription } from 'azure-arm-eventgrid/lib/models';
 import { DialogResponses, IAzureNode, IAzureTreeItem } from 'vscode-azureextensionui';
-import { extensionOutputChannel } from '../../extension';
+import { ext } from '../../extensionVariables';
 import { ArgumentError } from '../../utils/errors';
 import { localize } from '../../utils/localize';
 import { treeUtils } from '../../utils/treeUtils';
@@ -42,10 +42,10 @@ export class EventSubscriptionTreeItem implements IAzureTreeItem {
         const message: string = localize('confirmDelete', 'Are you sure you want to delete event subscription "{0}"?', this._name);
         await node.ui.showWarningMessage(message, DialogResponses.deleteResponse, DialogResponses.cancel);
 
-        extensionOutputChannel.show(true);
-        extensionOutputChannel.appendLine(localize('deleting', 'Deleting event subscription "{0}"...', this._name));
+        ext.outputChannel.show(true);
+        ext.outputChannel.appendLine(localize('deleting', 'Deleting event subscription "{0}"...', this._name));
         const client: EventGridManagementClient = new EventGridManagementClient(node.credentials, node.subscriptionId);
         await client.eventSubscriptions.deleteMethod(this._topic, this._name);
-        extensionOutputChannel.appendLine(localize('successfullyDeleted', 'Successfully deleted event subscription "{0}".', this._name));
+        ext.outputChannel.appendLine(localize('successfullyDeleted', 'Successfully deleted event subscription "{0}".', this._name));
     }
 }

--- a/src/extensionVariables.ts
+++ b/src/extensionVariables.ts
@@ -1,0 +1,21 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ExtensionContext, OutputChannel } from "vscode";
+import { AzureActionHandler, AzureTreeDataProvider, IAzureUserInput } from "vscode-azureextensionui";
+import TelemetryReporter from "vscode-extension-telemetry";
+
+/**
+ * Namespace for common variables used throughout the extension. They must be initialized in the activate() method of extension.ts
+ */
+export namespace ext {
+    export let outputChannel: OutputChannel;
+    export let ui: IAzureUserInput;
+    export let reporter: TelemetryReporter | undefined;
+    export let actionHandler: AzureActionHandler;
+    export let context: ExtensionContext;
+    export let topicTree: AzureTreeDataProvider;
+    export let eventSubscriptionTree: AzureTreeDataProvider;
+}

--- a/src/topic/createWizard/ITopicWizardContext.ts
+++ b/src/topic/createWizard/ITopicWizardContext.ts
@@ -1,0 +1,13 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Topic } from "azure-arm-eventgrid/lib/models";
+import { IResourceGroupWizardContext } from "vscode-azureextensionui";
+
+export interface ITopicWizardContext extends IResourceGroupWizardContext {
+    topic?: Topic;
+
+    newTopicName?: string;
+}

--- a/src/topic/createWizard/TopicCreateStep.ts
+++ b/src/topic/createWizard/TopicCreateStep.ts
@@ -1,0 +1,25 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// tslint:disable-next-line:no-require-imports
+import EventGridManagementClient = require('azure-arm-eventgrid');
+import { OutputChannel } from 'vscode';
+import { AzureWizardExecuteStep } from 'vscode-azureextensionui';
+import { localize } from '../../utils/localize';
+import { ITopicWizardContext } from './ITopicWizardContext';
+
+export class TopicCreateStep<T extends ITopicWizardContext> extends AzureWizardExecuteStep<T> {
+    public async execute(wizardContext: T, outputChannel: OutputChannel): Promise<T> {
+        if (!wizardContext.topic) {
+            outputChannel.appendLine(localize('creating', 'Creating topic "{0}"...', wizardContext.newTopicName));
+            const client: EventGridManagementClient = new EventGridManagementClient(wizardContext.credentials, wizardContext.subscriptionId);
+            // tslint:disable-next-line:no-non-null-assertion
+            wizardContext.topic = await client.topics.createOrUpdate(wizardContext.resourceGroup!.name!, wizardContext.newTopicName!, { location: wizardContext.location!.name! });
+            outputChannel.appendLine(localize('created', 'Successfully created topic "{0}".', wizardContext.newTopicName));
+        }
+
+        return wizardContext;
+    }
+}

--- a/src/topic/createWizard/TopicNameStep.ts
+++ b/src/topic/createWizard/TopicNameStep.ts
@@ -1,0 +1,46 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { AzureNameStep, IAzureUserInput, ResourceGroupListStep, resourceGroupNamingRules } from 'vscode-azureextensionui';
+import { localize } from '../../utils/localize';
+import { ITopicWizardContext } from './ITopicWizardContext';
+
+export class TopicNameStep<T extends ITopicWizardContext> extends AzureNameStep<T> {
+    public async prompt(wizardContext: T, ui: IAzureUserInput): Promise<T> {
+        if (!wizardContext.newTopicName) {
+            const suggestedName: string | undefined = wizardContext.relatedNameTask ? await wizardContext.relatedNameTask : undefined;
+            wizardContext.newTopicName = (await ui.showInputBox({
+                value: suggestedName,
+                placeHolder: localize('namePlaceholder', 'Topic name'),
+                prompt: localize('namePrompt', 'Provide a topic name.'),
+                validateInput: this.validateName
+            })).trim();
+
+            if (!wizardContext.relatedNameTask) {
+                wizardContext.relatedNameTask = this.generateRelatedName(wizardContext, wizardContext.newTopicName, resourceGroupNamingRules);
+            }
+        }
+
+        return wizardContext;
+    }
+
+    protected async isRelatedNameAvailable(wizardContext: T, name: string): Promise<boolean> {
+        return await ResourceGroupListStep.isNameAvailable(wizardContext, name);
+    }
+
+    private async validateName(name: string | undefined): Promise<string | undefined> {
+        name = name ? name.trim() : '';
+
+        const min: number = 3;
+        const max: number = 50;
+        if (name.length < min || name.length > max) {
+            return localize('invalidLength', 'The name must be between {0} and {1} characters.', min, max);
+        } else if (name.match(/[^a-zA-Z0-9\-]/) !== null) {
+            return localize('invalidChars', "The name can only contain letters, numbers, and hyphens.");
+        } else {
+            return undefined;
+        }
+    }
+}

--- a/src/topic/tree/TopicProvider.ts
+++ b/src/topic/tree/TopicProvider.ts
@@ -6,8 +6,12 @@
 // tslint:disable-next-line:no-require-imports
 import EventGridManagementClient = require('azure-arm-eventgrid');
 import { Topic, TopicsListResult } from 'azure-arm-eventgrid/lib/models';
-import { IAzureNode, IAzureTreeItem, IChildProvider } from 'vscode-azureextensionui';
+import { AzureWizard, IActionContext, IAzureNode, IAzureTreeItem, IChildProvider, LocationListStep, ResourceGroupListStep } from 'vscode-azureextensionui';
+import { ext } from '../../extensionVariables';
 import { localize } from '../../utils/localize';
+import { ITopicWizardContext } from '../createWizard/ITopicWizardContext';
+import { TopicCreateStep } from '../createWizard/TopicCreateStep';
+import { TopicNameStep } from '../createWizard/TopicNameStep';
 import { TopicTreeItem } from './TopicTreeItem';
 
 export class TopicProvider implements IChildProvider {
@@ -21,5 +25,36 @@ export class TopicProvider implements IChildProvider {
         const client: EventGridManagementClient = new EventGridManagementClient(node.credentials, node.subscriptionId);
         const topics: TopicsListResult = await client.topics.listBySubscription();
         return topics.map((topic: Topic) => new TopicTreeItem(topic));
+    }
+
+    public async createChild(node: IAzureNode, showCreatingNode: (label: string) => void, actionContext?: IActionContext): Promise<IAzureTreeItem> {
+        const wizardContext: ITopicWizardContext = {
+            credentials: node.credentials,
+            subscriptionId: node.subscriptionId,
+            subscriptionDisplayName: node.subscriptionDisplayName
+        };
+
+        const wizard: AzureWizard<ITopicWizardContext> = new AzureWizard(
+            [
+                new TopicNameStep(),
+                new ResourceGroupListStep(),
+                new LocationListStep()
+            ],
+            [
+                new TopicCreateStep()
+            ],
+            wizardContext
+        );
+
+        // https://github.com/Microsoft/vscode-azuretools/issues/120
+        // tslint:disable-next-line:strict-boolean-expressions
+        actionContext = actionContext || <IActionContext>{ properties: {}, measurements: {} };
+
+        await wizard.prompt(actionContext, ext.ui);
+        // tslint:disable-next-line:no-non-null-assertion
+        showCreatingNode(wizardContext.newTopicName!);
+        await wizard.execute(actionContext, ext.outputChannel);
+        // tslint:disable-next-line:no-non-null-assertion
+        return new TopicTreeItem(wizardContext.topic!);
     }
 }

--- a/src/topic/tree/TopicTreeItem.ts
+++ b/src/topic/tree/TopicTreeItem.ts
@@ -7,7 +7,7 @@
 import EventGridManagementClient = require('azure-arm-eventgrid');
 import { Topic } from 'azure-arm-eventgrid/lib/models';
 import { DialogResponses, IAzureNode, IAzureTreeItem } from 'vscode-azureextensionui';
-import { extensionOutputChannel } from '../../extension';
+import { ext } from '../../extensionVariables';
 import { azureUtils } from '../../utils/azureUtils';
 import { ArgumentError } from '../../utils/errors';
 import { localize } from '../../utils/localize';
@@ -43,10 +43,10 @@ export class TopicTreeItem implements IAzureTreeItem {
         const message: string = localize('confirmDelete', 'Are you sure you want to delete topic "{0}"?', this._name);
         await node.ui.showWarningMessage(message, DialogResponses.deleteResponse, DialogResponses.cancel);
 
-        extensionOutputChannel.show(true);
-        extensionOutputChannel.appendLine(localize('deleting', 'Deleting topic "{0}"...', this._name));
+        ext.outputChannel.show(true);
+        ext.outputChannel.appendLine(localize('deleting', 'Deleting topic "{0}"...', this._name));
         const client: EventGridManagementClient = new EventGridManagementClient(node.credentials, node.subscriptionId);
         await client.topics.deleteMethod(this._resourceGroup, this._name);
-        extensionOutputChannel.appendLine(localize('successfullyDeleted', 'Successfully deleted topic "{0}".', this._name));
+        ext.outputChannel.appendLine(localize('successfullyDeleted', 'Successfully deleted topic "{0}".', this._name));
     }
 }


### PR DESCRIPTION
Relies on this PR in the shared package: https://github.com/Microsoft/vscode-azuretools/pull/156

The portal supports all of these topic types when creating an event subscription, but I intentionally only support 4 in this first PR:
![screen shot 2018-04-17 at 9 49 42 am](https://user-images.githubusercontent.com/11282622/38884506-b5b5aa58-4224-11e8-82dd-3e06f35da17c.png)

Fixes #4 
FIxes #3