### PR TITLE
Add remaining event types for generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ script:
   - gulp package
   - gulp upload-vsix
   - npm run lint
-  - npm test
+  - gulp test
 
 notifications:
   email:

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,6 +8,14 @@ const path = require('path');
 const azureStorage = require('azure-storage');
 const vsce = require('vsce');
 const packageJson = require('./package.json');
+const cp = require('child_process');
+
+gulp.task('test', (cb) => {
+    const cmd = cp.spawn('node', ['./node_modules/vscode/bin/test'], { stdio: 'inherit' });
+    cmd.on('close', (code) => {
+        cb(code);
+    });
+});
 
 gulp.task('package', async () => {
     await vsce.createVSIX();

--- a/resources/templates/ContainerRegistry.json
+++ b/resources/templates/ContainerRegistry.json
@@ -1,0 +1,36 @@
+{
+    "description": "Schema of the data property of an Event Grid event for a Microsoft.ContainerRegistry event with additional metadata for generating mock values.",
+    "properties": {
+        "id": {
+            "description": "The event ID.",
+            "type": "string",
+            "chance": "guid"
+        },
+        "timestamp": {
+            "format": "date-time",
+            "description": "The time at which the event occurred.",
+            "type": "string"
+        },
+        "action": {
+            "description": "The action that encompasses the provided event.",
+            "type": "string",
+            "pattern": "(push|delete)"
+        },
+        "target": {
+            "$ref": "#/definitions/ContainerRegistryEventTarget",
+            "description": "The target of the event."
+        },
+        "request": {
+            "$ref": "#/definitions/ContainerRegistryEventRequest",
+            "description": "The request that generated the event."
+        },
+        "actor": {
+            "$ref": "#/definitions/ContainerRegistryEventActor",
+            "description": "The agent that initiated the event. For most situations, this could be from the authorization context of the request."
+        },
+        "source": {
+            "$ref": "#/definitions/ContainerRegistryEventSource",
+            "description": "The registry node that generated the event. Put differently, while the actor initiates the event, the source generates it."
+        }
+    }
+}

--- a/resources/templates/EventHub.json
+++ b/resources/templates/EventHub.json
@@ -1,0 +1,70 @@
+{
+    "description": "Schema of the Data property of an Event Grid event for an Microsoft.EventHub.CaptureFileCreated event with additional metadata for generating mock values.",
+    "type": "object",
+    "properties": {
+        "fileurl": {
+            "description": "The path to the capture file.",
+            "type": "string",
+            "chance": "url"
+        },
+        "fileType": {
+            "description": "The file type of the capture file.",
+            "type": "string",
+            "pattern": "AzureBlockBlob"
+        },
+        "partitionId": {
+            "description": "The shard ID.",
+            "type": "string"
+        },
+        "sizeInBytes": {
+            "description": "The file size.",
+            "type": "integer",
+            "chance": {
+                "integer": {
+                    "min": 0,
+                    "max": 1000000
+                }
+            }
+        },
+        "eventCount": {
+            "description": "The number of events in the file.",
+            "type": "integer",
+            "chance": {
+                "integer": {
+                    "min": 0,
+                    "max": 1000000
+                }
+            }
+        },
+        "firstSequenceNumber": {
+            "description": "The smallest sequence number from the queue.",
+            "type": "integer",
+            "chance": {
+                "integer": {
+                    "min": 0,
+                    "max": 1000000
+                }
+            }
+        },
+        "lastSequenceNumber": {
+            "description": "The last sequence number from the queue.",
+            "type": "integer",
+            "chance": {
+                "integer": {
+                    "min": 0,
+                    "max": 1000000
+                }
+            }
+        },
+        "firstEnqueueTime": {
+            "description": "The first time from the queue.",
+            "format": "date-time",
+            "type": "string"
+        },
+        "lastEnqueueTime": {
+            "description": "The last time from the queue.",
+            "format": "date-time",
+            "type": "string"
+        }
+    }
+}

--- a/resources/templates/IotHub.json
+++ b/resources/templates/IotHub.json
@@ -1,0 +1,28 @@
+{
+    "type": "object",
+    "description": "Schema of the Data property of an Event Grid event for a device life cycle event (DeviceCreated, DeviceDeleted) with additional metadata for generating mock values.",
+    "properties": {
+        "deviceId": {
+            "type": "string",
+            "description": "The unique identifier of the device. This case-sensitive string can be up to 128 characters long, and supports ASCII 7-bit alphanumeric characters plus the following special characters: - : . + % _ # * ? ! ( ) , = @ ; $ '."
+        },
+        "hubName": {
+            "type": "string",
+            "description": "Name of the IoT Hub where the device was created or deleted."
+        },
+        "opType": {
+            "type": "string",
+            "description": "The event type specified for this operation by the IoT Hub.",
+            "pattern": "(DeviceCreated|DeviceDeleted)"
+        },
+        "operationTimestamp": {
+            "type": "string",
+            "description": "The ISO8601 timestamp of the operation.",
+            "format": "date-time"
+        },
+        "twin": {
+            "description": "Information about the device twin, which is the cloud represenation of application device metadata.",
+            "$ref": "#/definitions/DeviceTwinInfo"
+        }
+    }
+}

--- a/resources/templates/IotHub.json
+++ b/resources/templates/IotHub.json
@@ -1,6 +1,6 @@
 {
     "type": "object",
-    "description": "Schema of the Data property of an Event Grid event for a device life cycle event (DeviceCreated, DeviceDeleted) with additional metadata for generating mock values.",
+    "description": "Schema of the Data property of an Event Grid event for a device lifecycle event (DeviceCreated, DeviceDeleted) with additional metadata for generating mock values.",
     "properties": {
         "deviceId": {
             "type": "string",

--- a/resources/templates/definitions/ContainerRegistry.json
+++ b/resources/templates/definitions/ContainerRegistry.json
@@ -1,0 +1,102 @@
+{
+    "ContainerRegistryEventTarget": {
+        "description": "The target of the event.",
+        "properties": {
+            "mediaType": {
+                "description": "The MIME type of the referenced object.",
+                "type": "string"
+            },
+            "size": {
+                "format": "int64",
+                "description": "The number of bytes of the content. Same as Length field.",
+                "type": "integer",
+                "chance": {
+                    "integer": {
+                        "min": 0,
+                        "max": 1000000
+                    }
+                }
+            },
+            "digest": {
+                "description": "The digest of the content, as defined by the Registry V2 HTTP API Specification.",
+                "type": "string",
+                "pattern": "sha256:[a-f0-9]{64}"
+            },
+            "length": {
+                "format": "int64",
+                "description": "The number of bytes of the content. Same as Size field.",
+                "type": "integer",
+                "chance": {
+                    "integer": {
+                        "min": 0,
+                        "max": 1000000
+                    }
+                }
+            },
+            "repository": {
+                "description": "The repository name.",
+                "type": "string",
+                "pattern": "[a-zA-Z0-9]+"
+            },
+            "url": {
+                "description": "The direct URL to the content.",
+                "type": "string"
+            },
+            "tag": {
+                "description": "The tag name.",
+                "type": "string",
+                "pattern": "[0-9]\\.[0-9]\\.[0-9]"
+            }
+        }
+    },
+    "ContainerRegistryEventRequest": {
+        "description": "The request that generated the event.",
+        "properties": {
+            "id": {
+                "description": "The ID of the request that initiated the event.",
+                "type": "string",
+                "chance": "guid"
+            },
+            "addr": {
+                "description": "The IP or hostname and possibly port of the client connection that initiated the event. This is the RemoteAddr from the standard http request.",
+                "type": "string"
+            },
+            "host": {
+                "description": "The externally accessible hostname of the registry instance, as specified by the http host header on incoming requests.",
+                "type": "string",
+                "pattern": "[a-zA-Z0-9]+\\.azurecr\\.io"
+            },
+            "method": {
+                "description": "The request method that generated the event.",
+                "type": "string",
+                "pattern": "(PUT|GET|DELETE|POST)"
+            },
+            "useragent": {
+                "description": "The user agent header of the request.",
+                "type": "string"
+            }
+        }
+    },
+    "ContainerRegistryEventActor": {
+        "description": "The agent that initiated the event. For most situations, this could be from the authorization context of the request.",
+        "properties": {
+            "name": {
+                "description": "The subject or username associated with the request context that generated the event.",
+                "type": "string"
+            }
+        }
+    },
+    "ContainerRegistryEventSource": {
+        "description": "The registry node that generated the event. Put differently, while the actor initiates the event, the source generates it.",
+        "properties": {
+            "addr": {
+                "description": "The IP or hostname and the port of the registry node that generated the event. Generally, this will be resolved by os.Hostname() along with the running port.",
+                "type": "string"
+            },
+            "instanceID": {
+                "description": "The running instance of an application. Changes after each restart.",
+                "type": "string"
+            }
+        }
+    }
+}

--- a/resources/templates/definitions/IotHub.json
+++ b/resources/templates/definitions/IotHub.json
@@ -1,0 +1,126 @@
+{
+    "DeviceTwinInfo": {
+        "type": "object",
+        "description": "Information about the device twin, which is the cloud represenation of application device metadata.",
+        "properties": {
+            "authenticationType": {
+                "type": "string",
+                "description": "Authentication type used for this device: either SAS, SelfSigned, or CertificateAuthority.",
+                "pattern": "(SAS|SelfSigned|CertificateAuthority)"
+            },
+            "cloudToDeviceMessageCount": {
+                "type": "number",
+                "description": "Count of cloud to device messages sent to this device.",
+                "chance": {
+                    "integer": {
+                        "min": 0,
+                        "max": 1000000
+                    }
+                }
+            },
+            "connectionState": {
+                "type": "string",
+                "description": "Whether the device is connected or disconnected.",
+                "pattern": "(Connected|Disconnected)"
+            },
+            "deviceId": {
+                "type": "string",
+                "description": "The unique identifier of the device twin.",
+                "pattern": "[a-zA-Z0-9]+"
+            },
+            "etag": {
+                "type": "string",
+                "description": "A piece of information that describes the content of the device twin. Each etag is guaranteed to be unique per device twin."
+            },
+            "lastActivityTime": {
+                "type": "string",
+                "description": "The ISO8601 timestamp of the last activity.",
+                "format": "date-time"
+            },
+            "properties": {
+                "type": "object",
+                "description": "Properties JSON element.",
+                "properties": {
+                    "desired": {
+                        "description": "A portion of the properties that can be written only by the application back-end, and read by the device.",
+                        "$ref": "#/definitions/DeviceTwinProperties"
+                    },
+                    "reported": {
+                        "description": "A portion of the properties that can be written only by the device, and read by the application back-end.",
+                        "$ref": "#/definitions/DeviceTwinProperties"
+                    }
+                }
+            },
+            "status": {
+                "type": "string",
+                "description": "Whether the device twin is enabled or disabled.",
+                "pattern": "(enabled|disabled)"
+            },
+            "statusUpdateTime": {
+                "type": "string",
+                "description": "The ISO8601 timestamp of the last device twin status update.",
+                "format": "date-time"
+            },
+            "version": {
+                "type": "number",
+                "description": "An integer that is incremented by one each time the device twin is updated.",
+                "chance": {
+                    "integer": {
+                        "min": 0,
+                        "max": 1000
+                    }
+                }
+            },
+            "x509Thumbprint": {
+                "type": "object",
+                "description": "The thumbprint is a unique value for the x509 certificate, commonly used to find a particular certificate in a certificate store. The thumbprint is dynamically generated using the SHA1 algorithm, and does not physically exist in the certificate.",
+                "properties": {
+                    "primaryThumbprint": {
+                        "type": "string",
+                        "description": "Primary thumbprint for the x509 certificate.",
+                        "pattern": "(null|[a-f0-9]{40})"
+                    },
+                    "secondaryThumbprint": {
+                        "type": "string",
+                        "description": "Secondary thumbprint for the x509 certificate.",
+                        "pattern": "(null|[a-f0-9]{40})"
+                    }
+                }
+            }
+        }
+    },
+    "DeviceTwinProperties": {
+        "type": "object",
+        "description": "A portion of the properties that can be written only by the application back-end, and read by the device.",
+        "properties": {
+            "metadata": {
+                "description": "Metadata information for the properties JSON document.",
+                "$ref": "#/definitions/DeviceTwinMetadata",
+                "x-ms-client-name": "$metadata"
+            },
+            "version": {
+                "type": "number",
+                "description": "Version of device twin properties.",
+                "x-ms-client-name": "$version",
+                "chance": {
+                    "integer": {
+                        "min": 0,
+                        "max": 1000
+                    }
+                }
+            }
+        }
+    },
+    "DeviceTwinMetadata": {
+        "type": "object",
+        "description": "Metadata information for the properties JSON document.",
+        "properties": {
+            "lastUpdated": {
+                "type": "string",
+                "description": "The ISO8601 timestamp of the last time the properties were updated.",
+                "x-ms-client-name": "$lastUpdated",
+                "format": "date-time"
+            }
+        }
+    }
+}

--- a/src/eventSubscription/commands/mock/IEventSchema.ts
+++ b/src/eventSubscription/commands/mock/IEventSchema.ts
@@ -11,4 +11,5 @@ export interface IEventSchema {
             default?: string
         }
     };
+    definitions?: object;
 }

--- a/src/eventSubscription/commands/mock/createMockEventGenerator.ts
+++ b/src/eventSubscription/commands/mock/createMockEventGenerator.ts
@@ -16,6 +16,9 @@ import { IMockEventGenerator } from './IMockEventGenerator';
 export enum EventType {
     Storage = 'Microsoft.Storage',
     Resources = 'Microsoft.Resources',
+    ContainerRegistry = 'Microsoft.ContainerRegistry',
+    Devices = 'Microsoft.Devices',
+    EventHub = 'Microsoft.EventHub',
     Custom = 'Fabrikam'
 }
 
@@ -40,6 +43,22 @@ export async function createMockEventGenerator(node?: IAzureNode<EventSubscripti
             eventSubTypePattern = 'Resource(Write|Delete)(Success|Failure|Cancel)';
             subjectPattern = '/subscriptions\/[a-zA-Z0-9]+\/resourceGroups\/[a-zA-Z0-9]+\/providers\/Microsoft\\.[a-zA-Z0-9]+\/[a-zA-Z0-9]+';
             break;
+        case EventType.ContainerRegistry:
+            fileName = 'ContainerRegistry';
+            eventSubTypePattern = 'Image(Pushed|Deleted)';
+            subjectPattern = '[a-zA-Z0-9]+:[0-9]\\.[0-9]\\.[0-9]';
+            break;
+        case EventType.Devices:
+            fileName = 'IotHub';
+            eventSubTypePattern = 'Device(Created|Deleted)';
+            subjectPattern = 'devices/[a-zA-Z0-9]+';
+            break;
+        case EventType.EventHub:
+            fileName = 'EventHub';
+            eventSubTypePattern = 'CaptureFileCreated';
+            // Get the event hub name from the topic id and use that as the subject
+            subjectPattern = node.treeItem.topic.substring(node.treeItem.topic.lastIndexOf('/') + 1);
+            break;
         case EventType.Custom:
             eventSubTypePattern = '[a-zA-Z0-9]+';
             subjectPattern = '[a-zA-Z0-9]+';
@@ -57,6 +76,11 @@ export async function createMockEventGenerator(node?: IAzureNode<EventSubscripti
     eventSchema.properties.topic.default = node.treeItem.topic;
     eventSchema.properties.eventType.pattern = `${eventType.replace('.', '\\.')}\\.${eventSubTypePattern}`;
     eventSchema.properties.subject.pattern = subjectPattern;
+
+    const definitionsPath: string = path.join(templatesPath, 'definitions', `${fileName}.json`);
+    if (await fse.pathExists(definitionsPath)) {
+        eventSchema.definitions = <{}>await fse.readJson(definitionsPath);
+    }
 
     const eventGenerator: IMockEventGenerator = {
         eventSubscriptionId: node.id,
@@ -78,6 +102,12 @@ function getEventTypeFromTopic(topic: string): EventType {
         return EventType.Resources;
     } else if (/^\/subscriptions\/.*\/resourceGroups\/.*\/providers\/microsoft.storage\/storageaccounts\/[^\/]+$/i.test(topic)) {
         return EventType.Storage;
+    } else if (/^\/subscriptions\/.*\/resourceGroups\/.*\/providers\/microsoft.containerregistry\/registries\/[^\/]+$/i.test(topic)) {
+        return EventType.ContainerRegistry;
+    } else if (/^\/subscriptions\/.*\/resourceGroups\/.*\/providers\/microsoft.devices\/iothubs\/[^\/]+$/i.test(topic)) {
+        return EventType.Devices;
+    } else if (/^\/subscriptions\/.*\/resourceGroups\/.*\/providers\/microsoft.eventhub\/namespaces\/[^\/]+$/i.test(topic)) {
+        return EventType.EventHub;
     } else if (/^\/subscriptions\/.*\/resourceGroups\/.*\/providers\/microsoft.eventgrid\/topics\/[^\/]+$/i.test(topic)) {
         return EventType.Custom;
     } else {

--- a/test/getEventTypeFromTopic.test.ts
+++ b/test/getEventTypeFromTopic.test.ts
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { EventType, getEventTypeFromTopic } from '../src/eventSubscription/commands/mock/createMockEventGenerator';
+
+suite('getEventTypeFromTopic Tests', () => {
+    test('ContainerRegistry', () => {
+        const result: string = getEventTypeFromTopic('/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testgroup/providers/Microsoft.ContainerRegistry/registries/testresource');
+        assert.equal(result, EventType.ContainerRegistry);
+    });
+
+    test('EventGridTopic', () => {
+        const result: string = getEventTypeFromTopic('/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testgroup/providers/Microsoft.EventGrid/topics/testresource');
+        assert.equal(result, EventType.Custom);
+    });
+
+    test('Devices', () => {
+        const result: string = getEventTypeFromTopic('/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testgroup/providers/Microsoft.Devices/IotHubs/testresource');
+        assert.equal(result, EventType.Devices);
+    });
+
+    test('EventHub', () => {
+        const result: string = getEventTypeFromTopic('/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testgroup/providers/Microsoft.EventHub/namespaces/testresource');
+        assert.equal(result, EventType.EventHub);
+    });
+
+    test('Subscription', () => {
+        const result: string = getEventTypeFromTopic('/subscriptions/00000000-0000-0000-0000-000000000000');
+        assert.equal(result, EventType.Resources);
+    });
+
+    test('ResourceGroup', () => {
+        const result: string = getEventTypeFromTopic('/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testgroup');
+        assert.equal(result, EventType.Resources);
+    });
+
+    test('Storage', () => {
+        const result: string = getEventTypeFromTopic('/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testgroup/providers/Microsoft.Storage/storageAccounts/testresource');
+        assert.equal(result, EventType.Storage);
+    });
+});


### PR DESCRIPTION
Added the following types:
1. ContainerRegistry
1. IotHub
1. EventHub

These aren't meant to be perfect, but they should be a good starting point that user's can then modify to suit their needs. For now these are just copied from the [schema repo](https://github.com/Azure/azure-rest-api-specs/tree/master/specification/eventgrid/data-plane) and manually modified with more info for generating mock properties.

We now support all types that the schema repo supports. I'm hoping it's not hard to keep up-to-date - but we can always investigate making this more dynamic if that becomes a problem.