### PR TITLE
Leverage parseError when EventGrid is not supported

### DIFF
--- a/package.json
+++ b/package.json
@@ -351,7 +351,7 @@
         "fs-extra": "^5.0.0",
         "json-schema-faker": "~0.5.0-rc15",
         "request-promise": "^4.2.2",
-        "vscode-azureextensionui": "~0.13.0",
+        "vscode-azureextensionui": "~0.13.1",
         "vscode-extension-telemetry": "^0.0.15",
         "vscode-nls": "^2.0.2"
     },

--- a/src/eventSubscription/tree/EventSubscriptionProvider.ts
+++ b/src/eventSubscription/tree/EventSubscriptionProvider.ts
@@ -7,7 +7,7 @@ import { EventGridManagementClient } from 'azure-arm-eventgrid';
 import { EventSubscription } from 'azure-arm-eventgrid/lib/models';
 import { SubscriptionClient } from 'azure-arm-resource';
 import { Location } from 'azure-arm-resource/lib/subscription/models';
-import { AzureWizard, IActionContext, IAzureNode, IAzureTreeItem, IChildProvider } from 'vscode-azureextensionui';
+import { AzureWizard, IActionContext, IAzureNode, IAzureTreeItem, IChildProvider, parseError } from 'vscode-azureextensionui';
 import { ext } from '../../extensionVariables';
 import { localize } from '../../utils/localize';
 import { EndpointUrlStep } from '../createWizard/EndpointUrlStep';
@@ -34,8 +34,7 @@ export class EventSubscriptionProvider implements IChildProvider {
                 return await client.eventSubscriptions.listRegionalBySubscription(location.name!);
             } catch (error) {
                 // Ignore errors for regions where EventGrid is not supported
-                // tslint:disable-next-line:no-unsafe-any
-                if (error && error.code === 'NoRegisteredProviderFound') {
+                if (parseError(error).errorType === 'NoRegisteredProviderFound') {
                     return [];
                 } else {
                     throw error;


### PR DESCRIPTION
I ran into a problem listing event subscriptions:
![screen shot 2018-05-31 at 1 52 47 pm](https://user-images.githubusercontent.com/11282622/40808853-62e17614-64dd-11e8-9b7b-e44ef0092edb.png)

For some reason the error being reported is different based on the subscription, but I should've been using parseError from the start anyways.
My subscription:
![screen shot 2018-05-31 at 2 00 28 pm](https://user-images.githubusercontent.com/11282622/40808822-432e8186-64dd-11e8-876a-a7055de05ad7.png)

Nathan's subsription (which I don't have full access to - which could explain the difference):
![screen shot 2018-05-31 at 2 01 06 pm](https://user-images.githubusercontent.com/11282622/40808835-50f79956-64dd-11e8-88d8-885a37771478.png)

There's still some work to be done similar to https://github.com/Microsoft/vscode-cosmosdb/issues/628, but IMO this is the smallest amount of work needed for this release.