### PR TITLE
Use long running notifications instead of opening output channel

### DIFF
--- a/src/eventSubscription/createWizard/EventSubscriptionCreateStep.ts
+++ b/src/eventSubscription/createWizard/EventSubscriptionCreateStep.ts
@@ -5,6 +5,7 @@
 
 import { EventGridManagementClient } from 'azure-arm-eventgrid';
 import { WebHookEventSubscriptionDestination } from 'azure-arm-eventgrid/lib/models';
+import * as vscode from 'vscode';
 import { AzureWizardExecuteStep, createAzureClient, IResourceGroupWizardContext, IStorageAccountWizardContext } from 'vscode-azureextensionui';
 import { ext } from '../../extensionVariables';
 import { ITopicWizardContext } from '../../topic/createWizard/ITopicWizardContext';
@@ -62,7 +63,9 @@ export class EventSubscriptionCreateStep extends AzureWizardExecuteStep<IEventSu
                 }
             });
 
-            ext.outputChannel.appendLine(localize('created', 'Successfully created event subscription "{0}".', wizardContext.newEventSubscriptionName));
+            const message: string = localize('created', 'Successfully created event subscription "{0}".', wizardContext.newEventSubscriptionName);
+            ext.outputChannel.appendLine(message);
+            vscode.window.showInformationMessage(message);
         }
 
         return wizardContext;

--- a/src/eventSubscription/tree/EventSubscriptionProvider.ts
+++ b/src/eventSubscription/tree/EventSubscriptionProvider.ts
@@ -7,6 +7,7 @@ import { EventGridManagementClient } from 'azure-arm-eventgrid';
 import { EventSubscription } from 'azure-arm-eventgrid/lib/models';
 import { SubscriptionClient } from 'azure-arm-resource';
 import { Location } from 'azure-arm-resource/lib/subscription/models';
+import * as vscode from 'vscode';
 import { AzureWizard, createAzureClient, createAzureSubscriptionClient, IActionContext, ISubscriptionRoot, parseError, SubscriptionTreeItem } from 'vscode-azureextensionui';
 import { localize } from '../../utils/localize';
 import { EndpointUrlStep } from '../createWizard/EndpointUrlStep';
@@ -66,7 +67,11 @@ export class EventSubscriptionProvider extends SubscriptionTreeItem {
         await wizard.prompt(actionContext);
         // tslint:disable-next-line:no-non-null-assertion
         showCreatingNode(wizardContext.newEventSubscriptionName!);
-        await wizard.execute(actionContext);
+        const message: string = localize('creatingEventSubscription', 'Creating event subscription "{0}"...', wizardContext.newEventSubscriptionName);
+        await vscode.window.withProgress({ title: message, location: vscode.ProgressLocation.Notification }, async () => {
+            // tslint:disable-next-line:no-non-null-assertion
+            await wizard.execute(actionContext!);
+        });
         // tslint:disable-next-line:no-non-null-assertion
         return new EventSubscriptionTreeItem(this, wizardContext.eventSubscription!);
     }

--- a/src/eventSubscription/tree/EventSubscriptionTreeItem.ts
+++ b/src/eventSubscription/tree/EventSubscriptionTreeItem.ts
@@ -5,6 +5,7 @@
 
 import { EventGridManagementClient } from 'azure-arm-eventgrid';
 import { EventSubscription } from 'azure-arm-eventgrid/lib/models';
+import * as vscode from 'vscode';
 import { AzureTreeItem, createAzureClient, DialogResponses } from 'vscode-azureextensionui';
 import { ext } from '../../extensionVariables';
 import { ArgumentError } from '../../utils/errors';
@@ -42,10 +43,10 @@ export class EventSubscriptionTreeItem extends AzureTreeItem {
         const message: string = localize('confirmDelete', 'Are you sure you want to delete event subscription "{0}"?', this.name);
         await ext.ui.showWarningMessage(message, { modal: true }, DialogResponses.deleteResponse, DialogResponses.cancel);
 
-        ext.outputChannel.show(true);
-        ext.outputChannel.appendLine(localize('deleting', 'Deleting event subscription "{0}"...', this.name));
         const client: EventGridManagementClient = createAzureClient(this.root, EventGridManagementClient);
-        await client.eventSubscriptions.deleteMethod(this.topic, this.name);
-        ext.outputChannel.appendLine(localize('successfullyDeleted', 'Successfully deleted event subscription "{0}".', this.name));
+        await vscode.window.withProgress({ title: localize('deleting', 'Deleting event subscription "{0}"...', this.name), location: vscode.ProgressLocation.Notification }, async () => {
+            await client.eventSubscriptions.deleteMethod(this.topic, this.name);
+        });
+        vscode.window.showInformationMessage(localize('successfullyDeleted', 'Successfully deleted event subscription "{0}".', this.name));
     }
 }

--- a/src/topic/createWizard/TopicCreateStep.ts
+++ b/src/topic/createWizard/TopicCreateStep.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { EventGridManagementClient } from 'azure-arm-eventgrid';
+import * as vscode from 'vscode';
 import { AzureWizardExecuteStep, createAzureClient } from 'vscode-azureextensionui';
 import { ext } from '../../extensionVariables';
 import { localize } from '../../utils/localize';
@@ -16,7 +17,9 @@ export class TopicCreateStep<T extends ITopicWizardContext> extends AzureWizardE
             const client: EventGridManagementClient = createAzureClient(wizardContext, EventGridManagementClient);
             // tslint:disable-next-line:no-non-null-assertion
             wizardContext.topic = await client.topics.createOrUpdate(wizardContext.resourceGroup!.name!, wizardContext.newTopicName!, { location: wizardContext.location!.name! });
-            ext.outputChannel.appendLine(localize('created', 'Successfully created topic "{0}".', wizardContext.newTopicName));
+            const message: string = localize('created', 'Successfully created topic "{0}".', wizardContext.newTopicName);
+            ext.outputChannel.appendLine(message);
+            vscode.window.showInformationMessage(message);
         }
 
         return wizardContext;

--- a/src/topic/tree/TopicProvider.ts
+++ b/src/topic/tree/TopicProvider.ts
@@ -5,6 +5,7 @@
 
 import { EventGridManagementClient } from 'azure-arm-eventgrid';
 import { Topic, TopicsListResult } from 'azure-arm-eventgrid/lib/models';
+import * as vscode from 'vscode';
 import { AzureWizard, createAzureClient, IActionContext, LocationListStep, ResourceGroupListStep, SubscriptionTreeItem } from 'vscode-azureextensionui';
 import { localize } from '../../utils/localize';
 import { ITopicWizardContext } from '../createWizard/ITopicWizardContext';
@@ -47,7 +48,11 @@ export class TopicProvider extends SubscriptionTreeItem {
         await wizard.prompt(actionContext);
         // tslint:disable-next-line:no-non-null-assertion
         showCreatingNode(wizardContext.newTopicName!);
-        await wizard.execute(actionContext);
+        const message: string = localize('creatingTopic', 'Creating topic "{0}"...', wizardContext.newTopicName);
+        await vscode.window.withProgress({ title: message, location: vscode.ProgressLocation.Notification }, async () => {
+            // tslint:disable-next-line:no-non-null-assertion
+            await wizard.execute(actionContext!);
+        });
         // tslint:disable-next-line:no-non-null-assertion
         return new TopicTreeItem(this, wizardContext.topic!);
     }

--- a/src/topic/tree/TopicTreeItem.ts
+++ b/src/topic/tree/TopicTreeItem.ts
@@ -5,6 +5,7 @@
 
 import { EventGridManagementClient } from 'azure-arm-eventgrid';
 import { Topic } from 'azure-arm-eventgrid/lib/models';
+import * as vscode from 'vscode';
 import { AzureTreeItem, createAzureClient, DialogResponses } from 'vscode-azureextensionui';
 import { ext } from '../../extensionVariables';
 import { azureUtils } from '../../utils/azureUtils';
@@ -44,10 +45,10 @@ export class TopicTreeItem extends AzureTreeItem {
         const message: string = localize('confirmDelete', 'Are you sure you want to delete topic "{0}"?', this._name);
         await ext.ui.showWarningMessage(message, { modal: true }, DialogResponses.deleteResponse, DialogResponses.cancel);
 
-        ext.outputChannel.show(true);
-        ext.outputChannel.appendLine(localize('deleting', 'Deleting topic "{0}"...', this._name));
         const client: EventGridManagementClient = createAzureClient(this.root, EventGridManagementClient);
-        await client.topics.deleteMethod(this._resourceGroup, this._name);
-        ext.outputChannel.appendLine(localize('successfullyDeleted', 'Successfully deleted topic "{0}".', this._name));
+        await vscode.window.withProgress({ title: localize('deleting', 'Deleting topic "{0}"...', this._name), location: vscode.ProgressLocation.Notification }, async () => {
+            await client.topics.deleteMethod(this._resourceGroup, this._name);
+        });
+        vscode.window.showInformationMessage(localize('successfullyDeleted', 'Successfully deleted topic "{0}".', this._name));
     }
 }


### PR DESCRIPTION
The ui package already moved over to notifications so I kinda have to do this before releasing otherwise it's a weird hodgepodge of notifications vs. output channel.