### PR TITLE
Remove sovereign support from changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ All notable changes to the "azureeventgrid" extension will be documented in this
 
 ### Added
 
-- Provisional support for sovereign accounts in Azure
 - Use notifications instead of opening output channel
 - Improved parsing of errors
 


### PR DESCRIPTION
Probably not worth testing all sovereigns so we'll just remove it from the changelog per Mr. Jing